### PR TITLE
use latest config gem

### DIFF
--- a/config.gemspec
+++ b/config.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_dependency "activesupport",           ">= 3.0"
-  s.add_dependency "deep_merge",              "~> 1.0.1"
+  s.add_dependency "deep_merge",              "~> 1.1.1"
 
   s.add_development_dependency "bundler",     "~> 1.11.2"
   s.add_development_dependency "rake"


### PR DESCRIPTION
A newer version of `deep_merge` gem has been released (with @Fryguy's changes)
Not sure how quickly https://github.com/railsconfig/config/pull/137 will get merged / released. so in the mean time, lets make our gem as similar to that PR and use the gem version of `deep_merge`

/cc @Fryguy 
